### PR TITLE
Update table.insert to have correct syntax

### DIFF
--- a/src/app/docs/functions/table/(methods)/insert/page.mdx
+++ b/src/app/docs/functions/table/(methods)/insert/page.mdx
@@ -10,7 +10,7 @@ The `table.insert()` function adds a new value to a table at a specified index. 
 ## Syntax
 
 ```lua
-table.insert(tableData, value, position)
+table.insert(tableData, position, value)
 ```
 
 ## Parameters


### PR DESCRIPTION
table.insert syntax is wrong, even the examples show the correct syntax.